### PR TITLE
Add vagrantfile with quick config

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+site :opscode
+
+cookbook 'apt'
+cookbook 'nginx'
+
+# Solely for the Vagrantfile to be able to use chef-solo
+# + data bags
+cookbook 'chef-solo-search',
+  :git => 'https://github.com/edelight/chef-solo-search/',
+  :ref => '1f79c1d86e85aa3a2b01e15f90755cf60eb66a4f'
+
+metadata
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,47 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile for rstudio-chef
+
+Vagrant.configure("2") do |config|
+
+  # Name the box for Vagrant
+  config.vm.define :RStudio
+
+  config.vm.provider "virtualbox" do |ipybox|
+     ipybox.name = "RStudio"
+  end
+
+  config.vm.hostname = "rstudio-server"
+
+  config.omnibus.chef_version = "11.6.0"
+
+  config.vm.box = "opscode-ubuntu-12.04"
+  config.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/opscode_ubuntu-12.04_provisionerless.box"
+
+  config.vm.network :private_network, ip: "33.33.33.11"
+  config.vm.network :forwarded_port, guest: 8787, host: 8787
+
+  config.ssh.max_tries = 40
+  config.ssh.timeout   = 120
+
+  # Enabling the Berkshelf plugin. To enable this globally, add this configuration
+  # option to your ~/.vagrant.d/Vagrantfile file
+  config.berkshelf.enabled = true
+
+  config.vm.provision :chef_solo do |chef|
+    chef.data_bags_path = "test/data_bags"
+    chef.json = {
+    }
+
+    chef.run_list = [
+        "recipe[chef-solo-search]",
+        "recipe[apt]",
+        "recipe[rstudio::default]",
+        "recipe[rstudio::cran]", # rstudio::cran must come before rstudio::server
+        "recipe[rstudio::server]",
+        "recipe[rstudio::pam]"
+    ]
+  end
+end
+

--- a/test/data_bags/users/rs.json
+++ b/test/data_bags/users/rs.json
@@ -1,0 +1,9 @@
+{
+  "id": "rs",
+  "groups": "rs",
+  "uid": 2001,
+  "shell": "/bin/bash",
+  "rstudio": {
+      "passwd": "WQtdiGghp/GSU"
+  }
+}


### PR DESCRIPTION
Added a simple vagrantfile and a databag for testing purposes (within test), solely for use by the Vagrantfile. We can use this while developing the cookbook further. I do make the assumption that we can use Berkshelf and Omnibus for the Vagrantfile. If warranted, I can add instructions for installing those.
