### PR TITLE
Retrieve rstudio-server pkg direct from rstudio.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Berksfile.lock
 Gemfile.lock
 *.swp
+*.bak

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,11 +18,14 @@ end
 default['rstudio']['cran']['packages'] = []
 
 # RStudio Server
+default['rstudio']['server']['base_download_url'] = 'http://download2.rstudio.org'
 default['rstudio']['server']['www_port'] = '8787'
 default['rstudio']['server']['www_address'] = '127.0.0.1'
 default['rstudio']['server']['ld_library_path'] = ''
 default['rstudio']['server']['r_binary_path'] = ''
 default['rstudio']['server']['user_group'] = ''
+default['rstudio']['server']['version'] = '0.98.507'
+default['rstudio']['server']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "i386"
 
 # RStudio Session
 default['rstudio']['session']['timeout'] = '30'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -14,9 +14,27 @@ when "ubuntu", "debian"
         action :install
     end
 
-    package "rstudio-server" do
+    package "libssl0.9.8" do
         action :install
     end
+
+    Chef::Log.info('Retrieving RStudio Server file.')
+    remote_rstudio_server_file = "#{node['rstudio']['server']['base_download_url']}/rstudio-server-#{node['rstudio']['server']['version']}-#{node['rstudio']['server']['arch']}.deb"
+    local_rstudio_server_file = "#{Chef::Config[:file_cache_path]}/rstudio-server-#{node['rstudio']['server']['version']}-#{node['rstudio']['server']['arch']}.deb"
+    remote_file local_rstudio_server_file do
+        source remote_rstudio_server_file 
+        action :create_if_missing
+        not_if { ::File.exists?('/etc/init/shiny-server.conf') }
+    end
+
+    Chef::Log.info('Installing RStudio Server via dpkg.')
+    dpkg_package "rstudio-server" do
+      source local_rstudio_server_file
+      action :upgrade
+    end
+
+when "redhat", "centos", "fedora"
+    Chef::Application.fatal!("Redhat based platforms are not yet supported")
 end
 
 service "rstudio-server" do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,6 +1,6 @@
 # Set up the package repository.
-case node["platform"].downcase
-when "ubuntu", "debian"
+case platform_family
+when "debian"
     include_recipe "apt"
 
     apt_repository "rstudio-cran" do
@@ -33,7 +33,7 @@ when "ubuntu", "debian"
       action :upgrade
     end
 
-when "redhat", "centos", "fedora"
+when "rhel"
     Chef::Application.fatal!("Redhat based platforms are not yet supported")
 end
 


### PR DESCRIPTION
There are no public repos that contain the rstudio-server package. This PR duplicates the pattern used for the shiny server to construct a download URL and pull the pkg file from rstudio.com.
