### PR TITLE
More secure nginx default SSL config

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,6 +34,12 @@ default['rstudio']['nginx']['port'] = '80'
 default['rstudio']['nginx']['server_name'] = ''
 default['rstudio']['nginx']['location'] = '/'
 default['rstudio']['nginx']['shiny_location'] = ''
+default['rstudio']['nginx']['ssl_protocols'] = 'TLSv1.2'
+default['rstudio']['nginx']['ssl_session_timeout'] = '5m'
+default['rstudio']['nginx']['ssl_session_cache'] = 'shared:SSL:50m'
+default['rstudio']['nginx']['ssl_dhparam'] = ''  # Recommended to set
+default['rstudio']['nginx']['ssl_ciphers'] = 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'
+default['rstudio']['nginx']['hsts_max_age'] = 15768000  # 15768000 seconds = 6 months
 
 # SSL certificates
 default['rstudio']['ssl']['crt_file'] = ''

--- a/templates/default/etc/nginx/rstudio.conf.erb
+++ b/templates/default/etc/nginx/rstudio.conf.erb
@@ -12,8 +12,16 @@ server {
   ssl                       on;
   ssl_certificate           <%= node[:rstudio][:ssl][:crt_file] %>;
   ssl_certificate_key       <%= node[:rstudio][:ssl][:key_file] %>;
-  ssl_protocols             SSLv3 TLSv1;
-  ssl_ciphers               ALL:!aNULL:!ADH:!eNULL:!LOW:!EXP:RC4+RSA:+HIGH:+MEDIUM;
+  ssl_protocols             <%= node[:rstudio][:nginx][:ssl_protocols] %>;
+  ssl_session_timeout       <%= node[:rstudio][:nginx][:ssl_session_timeout] %>;
+  ssl_session_cache         <%= node[:rstudio][:nginx][:ssl_session_cache] %>;
+  <% if !node[:rstudio][:nginx][:ssl_dhparam].empty? %>
+  ssl_dhparam               <%= node[:rstudio][:nginx][:ssl_dhparam] %>;
+  <% end %>
+  ssl_ciphers               <%= node[:rstudio][:nginx][:ssl_ciphers] %>;
+  ssl_prefer_server_ciphers on;
+  add_header Strict-Transport-Security max-age=<%= node[:rstudio][:nginx][:hsts_max_age] %>;
+
   <% else %>
   listen        <%= node[:rstudio][:nginx][:port] %>;
   <% end %>


### PR DESCRIPTION
Parameterize nginx SSL config and default to Mozilla's recommended modern profile for nginx

https://mozilla.github.io/server-side-tls/ssl-config-generator/
https://wiki.mozilla.org/Security/Server_Side_TLS
