### PR TITLE
Update for Amazon Linux and general linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Berksfile.lock
 Gemfile.lock
 *.swp
+*.bak

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ Berksfile.lock
 Gemfile.lock
 *.swp
 *.bak
+.kitchen/
+.kitchen.local.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Berksfile.lock
 Gemfile.lock
 *.swp
+.kitchen/
+.kitchen.local.yml

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,37 +1,64 @@
 ---
 driver:
-  name: docker
+  name: dokken
+  chef_verison: latest
+
+transport:
+  name: dokken
 
 provisioner:
-  name: chef_zero
+  name: dokken
+
+verifier:
+  name: inspec
 
 platforms:
-  - name: ubuntu-14.04
-  - name: centos-7.1
-  - name: amazon
+  - name: ubuntu-18.04
     driver:
-      username: ec2-user
+      image: dokken/ubuntu-18.04
+      privileged: true
+      pid_one_command: /bin/systemd
+  - name: ubuntu-16.04
+    driver:
+      image: dokken/ubuntu-16.04
+      privileged: true
+      pid_one_command: /bin/systemd
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+      privileged: true
+      pid_one_command: /usr/lib/systemd/systemd
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+  - name: debian-9
+    driver:
+      image: dokken/debian-9
+      privileged: true
+      pid_one_command: /bin/systemd
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
+  - name: amazon
+    driver_config:
+      image: dokken/amazonlinux-2
+      privileged: true
+      pid_one_command: /usr/lib/systemd/systemd
+      volumes:
+        - /sys/fs/cgroup:/sys/fs/cgroup:ro # required by systemd
 
 suites:
   - name: default
     run_list:
-
       - recipe[rstudio::cran]
       - recipe[rstudio::server]
 
-    attributes:
-        r:
-            version: "3.5.0"
-            checksum: "9c9152e74134b68b0f3a1c7083764adc1cb56fd8336bec003fd0ca550cd2461d"
-            config_opts: [ "--enable-R-shlib=yes", "--with-x=no", "--prefix=/usr/local" ]
-
-  - name: users
+  - name: shiny
     data_bags_path: "test/integration/default/data_bags"
     run_list:
-
       - recipe[rstudio::cran]
       - recipe[rstudio::nginx]
       - recipe[rstudio::server]
-      - recipe[rstudio::users]
-
+      - recipe[rstudio::shiny]
     attributes:
+      rstudio:
+        nginx:
+          server_name: "localhost"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,9 +1,6 @@
 ---
 driver:
-  name: vagrant
-  network:
-    - ["forwarded_port", {guest: 8787, host: 8787}]
-    - ["private_network", {ip: "192.168.33.33"}]
+  name: docker
 
 provisioner:
   name: chef_zero
@@ -24,7 +21,7 @@ suites:
 
     attributes:
         r:
-            version: "3.2.2"
+            version: "3.5.0"
             checksum: "9c9152e74134b68b0f3a1c7083764adc1cb56fd8336bec003fd0ca550cd2461d"
             config_opts: [ "--enable-R-shlib=yes", "--with-x=no", "--prefix=/usr/local" ]
 

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,18 +1,36 @@
 ---
 driver:
   name: vagrant
+  network:
+    - ["forwarded_port", {guest: 8787, host: 8787}]
+    - ["private_network", {ip: "192.168.33.33"}]
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
 
 platforms:
   - name: ubuntu-14.04
   - name: centos-7.1
+  - name: amazon
+    driver:
+      username: ec2-user
 
 suites:
   - name: default
     run_list:
 
-      - recipe[rstudio::default]
+      - recipe[rstudio::cran]
+      - recipe[rstudio::server]
+
+    attributes:
+
+  - name: users
+    data_bags_path: "test/integration/default/data_bags"
+    run_list:
+
+      - recipe[rstudio::cran]
+      - recipe[rstudio::nginx]
+      - recipe[rstudio::server]
+      - recipe[rstudio::users]
 
     attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,0 +1,18 @@
+---
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
+
+platforms:
+  - name: ubuntu-14.04
+  - name: centos-7.1
+
+suites:
+  - name: default
+    run_list:
+
+      - recipe[rstudio::default]
+
+    attributes:

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,10 @@ suites:
       - recipe[rstudio::server]
 
     attributes:
+        r:
+            version: "3.2.2"
+            checksum: "9c9152e74134b68b0f3a1c7083764adc1cb56fd8336bec003fd0ca550cd2461d"
+            config_opts: [ "--enable-R-shlib=yes", "--with-x=no", "--prefix=/usr/local" ]
 
   - name: users
     data_bags_path: "test/integration/default/data_bags"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: ruby
+services: 
+  - docker
 rvm:
-    - 2.0.0
+    - 2.3.1
 before_install:
-    - gem update bundler
+  - gem update --system
+  - gem --version
 before_script:
     - bundle exec foodcritic -f any .
+    - bundle exec rake
+    - bundle exec kitchen verify default-ubuntu-18
+

--- a/Berksfile
+++ b/Berksfile
@@ -3,4 +3,5 @@ metadata
 
 cookbook 'apt', '~> 2.9.2'
 cookbook 'nginx', '~> 2.7.6'
+cookbook 'chef-sugar', "~> 3.1"
 cookbook 'r', github: 'stevendanna/cookbook-r'

--- a/Berksfile
+++ b/Berksfile
@@ -1,6 +1,8 @@
 source "http://api.berkshelf.com"
 metadata
 
+cookbook 'chef-sugar', "~> 3.1"
 cookbook 'apt', github: 'opscode-cookbooks/apt', tag: 'v2.3.0'
-cookbook 'nginx', github: 'opscode-cookbooks/nginx', tag: 'v2.2.0'
+cookbook 'nginx'
+#cookbook 'nginx', github: 'opscode-cookbooks/nginx', tag: 'v2.2.0'
 cookbook 'r', github: 'stevendanna/cookbook-r'

--- a/Berksfile
+++ b/Berksfile
@@ -4,4 +4,5 @@ metadata
 cookbook 'apt', '~> 7.1'
 cookbook 'nginx', '~> 9.0'
 cookbook 'chef-sugar', "~> 5.0"
-cookbook 'r', github: 'stevendanna/cookbook-r'
+cookbook 'r', github: 'davidski/chef-r', 'chef14'
+#cookbook 'r', path: "../chef-r"

--- a/Berksfile
+++ b/Berksfile
@@ -1,8 +1,7 @@
 source "https://api.berkshelf.com"
 metadata
 
-cookbook 'apt', '~> 2.9.2'
-cookbook 'nginx', '~> 2.7.6'
-cookbook 'chef-sugar', "~> 3.1"
-cookbook 'nginx'
+cookbook 'apt', '~> 7.1'
+cookbook 'nginx', '~> 9.0'
+cookbook 'chef-sugar', "~> 5.0"
 cookbook 'r', github: 'stevendanna/cookbook-r'

--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,5 @@ gem 'foodcritic', '~> 3.0'
 gem 'chef-zero', '~> 1.7'
 gem 'chefspec', :git => 'https://github.com/sethvargo/chefspec.git', :tag => 'v3.1.0.beta.1'
 gem 'fauxhai', '~> 2.0'
+gem "test-kitchen"
+gem "kitchen-vagrant"

--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,9 @@
 source 'https://rubygems.org'
 
 gem "berkshelf", '~> 4.0'
-gem 'vagrant-berkshelf', '~> 4.0'
-gem 'vagrant-omnibus', '~> 1.4'
 gem 'foodcritic', '~> 3.0'
 gem 'chef-zero', '~> 4.0'
-gem 'chefspec', '~> 4.5'
-gem 'fauxhai', '~> 2.0'
+gem 'chefspec', '~> 7.3'
+gem 'fauxhai', '~> 4.0'
 gem "test-kitchen"
-gem "kitchen-docker"
-gem "kitchen-vagrant"
+gem "kitchen-dokken"

--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,6 @@ gem 'vagrant-omnibus', '~> 1.4'
 gem 'foodcritic', '~> 3.0'
 gem 'chef-zero', '~> 4.0'
 gem 'chefspec', '~> 4.5'
+gem 'fauxhai', '~> 2.0'
+gem "test-kitchen"
+gem "kitchen-vagrant"

--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ gem 'chef-zero', '~> 4.0'
 gem 'chefspec', '~> 4.5'
 gem 'fauxhai', '~> 2.0'
 gem "test-kitchen"
+gem "kitchen-docker"
 gem "kitchen-vagrant"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Description
 
-This cookbook will install RStudio Server along with some extras that will configure various usages. In addition to installing the server, it can optionally set up CRAN's distribution-specific repositories, configure various Nginx options (SSL, proxy, and alternate locations), as well as an alternative to the default PAM configuration that doe *not* rely on a local user account.
+This cookbook will install RStudio Server along with some extras that will 
+configure various usages. In addition to installing the server, it can 
+optionally set up CRAN's distribution-specific repositories, configure various 
+Nginx options (SSL, proxy, and alternate locations), as well as an 
+alternative to the default PAM configuration that does *not* rely on a local 
+user account.
 
-* `rstudio::server` will download and configure the RServer packages.
+* `rstudio::server` will download and configure the RStudio Server package.
 * `rstudio::pam` will install the PAM [pam_pwdfile](https://github.com/tiwe-de/libpam-pwdfile) module. This module allows you to define username/password combinations using the `mkpasswd` utility. This allows you to give access to RStudio Server *without* creating accounts on the server itself.
 * `rstudio::cran` will install R packages listed in `node['rstudio']['cran']['packages']` using `r_package` from the [r](https://github.com/stevendanna/cookbook-r/) cookbook.
 * `rstudio::nginx` will configure an Nginx site for RStudio. It offers the ability to proxy via a separate URL as well as basic SSL support. When coupled with `rstudio::pam`, you can give remote access to RStudio via Nginx over SSL to people *without* direct access to the server via SSH.

--- a/Rakefile
+++ b/Rakefile
@@ -3,3 +3,10 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+begin
+  require "kitchen/rake_tasks"
+  Kitchen::RakeTasks.new
+rescue LoadError
+  puts ">>>>> Kitchen gem not loaded, omitting tasks" unless ENV["CI"]
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,11 +18,14 @@ end
 default['rstudio']['cran']['packages'] = []
 
 # RStudio Server
+default['rstudio']['server']['base_download_url'] = 'http://download2.rstudio.org'
 default['rstudio']['server']['www_port'] = '8787'
 default['rstudio']['server']['www_address'] = '127.0.0.1'
 default['rstudio']['server']['ld_library_path'] = ''
 default['rstudio']['server']['r_binary_path'] = ''
 default['rstudio']['server']['user_group'] = ''
+default['rstudio']['server']['version'] = '0.98.507'
+default['rstudio']['server']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "i386"
 
 # RStudio Session
 default['rstudio']['session']['timeout'] = '30'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,7 @@ default['rstudio']['server']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "
 # RStudio Session
 default['rstudio']['session']['timeout'] = '30'
 default['rstudio']['session']['package_path'] = ''
-default['rstudio']['session']['cran_repo'] = 'http://cran.case.edu/'
+default['rstudio']['session']['cran_repo'] = 'https://cran.fhcrc.org/'
 
 # Nginx
 default['rstudio']['nginx']['port'] = '80'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,7 +24,7 @@ default['rstudio']['server']['www_address'] = '127.0.0.1'
 default['rstudio']['server']['ld_library_path'] = ''
 default['rstudio']['server']['r_binary_path'] = ''
 default['rstudio']['server']['user_group'] = ''
-default['rstudio']['server']['version'] = '0.98.507'
+default['rstudio']['server']['version'] = '0.99.483'
 default['rstudio']['server']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "i386"
 
 # RStudio Session

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,13 +24,13 @@ default['rstudio']['server']['www_address'] = '127.0.0.1'
 default['rstudio']['server']['ld_library_path'] = ''
 default['rstudio']['server']['r_binary_path'] = ''
 default['rstudio']['server']['user_group'] = ''
-default['rstudio']['server']['version'] = '0.99.483'
+default['rstudio']['server']['version'] = '1.1.463'
 default['rstudio']['server']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "i386"
 
 # RStudio Session
 default['rstudio']['session']['timeout'] = '30'
 default['rstudio']['session']['package_path'] = ''
-default['rstudio']['session']['cran_repo'] = 'https://cran.fhcrc.org/'
+default['rstudio']['session']['cran_repo'] = 'https://cloud.r-project.org/'
 
 # Nginx
 default['rstudio']['nginx']['port'] = '80'
@@ -51,7 +51,7 @@ default['rstudio']['shiny']['log_dir'] = '/var/log/shiny-server'
 default['rstudio']['shiny']['directory_index'] = 'on'
 
 # Shiny can't be installed by APT. Don't get me started.
-default['rstudio']['shiny']['version'] = '0.4.0.8'
+default['rstudio']['shiny']['version'] = '1.5.9.923'
 default['rstudio']['shiny']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "i386"
 
 # Shiny server supports the users cookbook for HTTP Auth

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,18 +1,6 @@
 # CRAN
 default['rstudio']['cran']['mirror'] = 'https://cran.rstudio.com/'
 
-# APT configuration for Ubuntu or Debian installs.
-case node["platform"].downcase  
-when "ubuntu"
-    default['rstudio']['apt']['key'] = 'E084DAB9'
-    default['rstudio']['apt']['keyserver'] = 'keyserver.ubuntu.com'
-    default['rstudio']['apt']['uri'] = 'http://cran.stat.ucla.edu/bin/linux/ubuntu'
-when "debian"
-    default['rstudio']['apt']['key'] = '381BA480'
-    default['rstudio']['apt']['keyserver'] = 'subkeys.pgp.net'
-    default['rstudio']['apt']['uri'] = 'http://cran.stat.ucla.edu/bin/linux/debian'
-end
-
 # You can define a simple array of packages in your role/environment/node and the 
 # CRAN recipe will install them.
 default['rstudio']['cran']['packages'] = []

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,5 +1,5 @@
 # CRAN
-default['rstudio']['cran']['mirror'] = 'http://cran.rstudio.com/'
+default['rstudio']['cran']['mirror'] = 'https://cran.rstudio.com/'
 
 # APT configuration for Ubuntu or Debian installs.
 case node["platform"].downcase  
@@ -50,7 +50,7 @@ default['rstudio']['shiny']['site_dir'] = '/var/shiny-server/www'
 default['rstudio']['shiny']['log_dir'] = '/var/log/shiny-server'
 default['rstudio']['shiny']['directory_index'] = 'on'
 
-# Shiny can't be installe by APT. Don't get me started.
+# Shiny can't be installed by APT. Don't get me started.
 default['rstudio']['shiny']['version'] = '0.4.0.8'
 default['rstudio']['shiny']['arch'] = node['kernel']['machine'] =~ /x86_64/ ? "amd64" : "i386"
 

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,1 @@
+.kitchen

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,9 +7,11 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.0'
 supports         'ubuntu', '>= 12.04'
 supports         'redhat'
+supports         'centos'
 supports				 'amazon'
 
 depends "apt"
 depends "nginx"
 depends "r"
 depends "chef-sugar"
+depends "yum-epel"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,16 +5,17 @@ maintainer_email 'joe@joestump.net'
 license          'MIT'
 description      'Installs/Configures rstudio'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.5.0'
 source_url       'https://github.com/sprintly/rstudio-chef' if respond_to?(:source_url)
 issues_url       'https://github.com/sprintly/rstudio-chef/issues' if respond_to?(:issues_url)
-supports         'ubuntu', '>= 12.04'
-supports         'redhat'
+
+supports         'ubuntu', '>= 16.04'
+supports         'debian'
 supports         'centos'
 supports         'amazon'
 
-depends "apt"
-depends "nginx"
-depends "r"
-depends "chef-sugar"
-depends "yum-epel"
+depends          "apt"
+depends          "chef-sugar"
+depends          "nginx"
+depends          "r", '~> 0.4.0'
+depends          "yum-epel"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,9 @@ license          'BSD'
 description      'Installs/Configures rstudio'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.0'
+supports         'ubuntu', '>= 12.04'
+supports         'redhat'
+supports         'amazon'
 
 depends "apt"
 depends "nginx"

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,9 +7,11 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.0'
 supports         'ubuntu', '>= 12.04'
 supports         'redhat'
-supports         'amazon'
+supports         'centos'
+supports				 'amazon'
 
 depends "apt"
 depends "nginx"
 depends "r"
 depends "chef-sugar"
+depends "yum-epel"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,6 +5,9 @@ license          'All rights reserved'
 description      'Installs/Configures rstudio'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.0'
+supports         'ubuntu', '>= 12.04'
+supports         'redhat'
+supports				 'amazon'
 
 depends "apt"
 depends "nginx"

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,4 @@ version          '0.3.0'
 depends "apt"
 depends "nginx"
 depends "r"
+depends "chef-sugar"

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,8 @@
 name             'rstudio'
+chef_version     '>= 14'
 maintainer       'Sprint.ly, Inc.'
 maintainer_email 'joe@joestump.net'
-license          'BSD'
+license          'MIT'
 description      'Installs/Configures rstudio'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,4 @@ version          '0.4.0'
 depends "apt"
 depends "nginx"
 depends "r"
+depends "chef-sugar"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,10 +5,12 @@ license          'All rights reserved'
 description      'Installs/Configures rstudio'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.3.0'
+source_url       'https://github.com/sprintly/rstudio-chef' if respond_to?(:source_url)
+issues_url       'https://github.com/sprintly/rstudio-chef/issues' if respond_to?(:issues_url)
 supports         'ubuntu', '>= 12.04'
 supports         'redhat'
 supports         'centos'
-supports				 'amazon'
+supports         'amazon'
 
 depends "apt"
 depends "nginx"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,10 +5,12 @@ license          'BSD'
 description      'Installs/Configures rstudio'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.4.0'
+source_url       'https://github.com/sprintly/rstudio-chef' if respond_to?(:source_url)
+issues_url       'https://github.com/sprintly/rstudio-chef/issues' if respond_to?(:issues_url)
 supports         'ubuntu', '>= 12.04'
 supports         'redhat'
 supports         'centos'
-supports				 'amazon'
+supports         'amazon'
 
 depends "apt"
 depends "nginx"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,6 +4,4 @@
 #
 # Copyright 2013, Sprint.ly, Inc.
 #
-# All rights reserved - Do Not Redistribute
-#
 

--- a/recipes/nginx.rb
+++ b/recipes/nginx.rb
@@ -10,6 +10,8 @@ end
 case node["platform"].downcase
 when "ubuntu"
     template_file = "/etc/nginx/sites-available/#{server_name}"
+when "debian"
+    template_file = "/etc/nginx/sites-available/#{server_name}"
 end
 
 if node['rstudio']['ssl']['crt_file'] != '' && node['rstudio']['ssl']['crt_file'] != ''

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -15,49 +15,61 @@ if debian?
         action :install
     end
 
-    package "libssl0.9.8" do
-        action :install
-    end
+    #package "libssl0.9.8" do
+    #    action :install
+    #end
 
-    Chef::Log.info('Retrieving RStudio Server file.')
     remote_rstudio_server_file = "#{node['rstudio']['server']['base_download_url']}/rstudio-server-#{node['rstudio']['server']['version']}-#{node['rstudio']['server']['arch']}.deb"
     local_rstudio_server_file = "#{Chef::Config[:file_cache_path]}/rstudio-server-#{node['rstudio']['server']['version']}-#{node['rstudio']['server']['arch']}.deb"
-    remote_file local_rstudio_server_file do
-        source remote_rstudio_server_file 
-        action :create_if_missing
-        not_if { ::File.exists?('/etc/init/shiny-server.conf') }
-    end
 
-    Chef::Log.info('Installing RStudio Server via dpkg.')
-    dpkg_package "rstudio-server" do
-      source local_rstudio_server_file
-      action :upgrade
-    end
 end
 
 if rhel?
     # Chef::Application.fatal!("Redhat based platforms are not yet supported")
+    
+    include_recipe 'yum-epel'
+    
     package "R" do
         action :install
     end
-    
-    remote_file 'rstudio' do
-        source 'https://download2.rstudio.org/rstudio-server-rhel-0.99.483-x86_64.rpm'
-        action :create_if_missing
+
+    if _64_bit?
+        arch = "x86_64"
+    else
+        arch = "i686"
     end
-    
-    package 'rstudio' do
-        source 'rstudio'
-        action :install
-    end
+		
+    remote_rstudio_server_file = "#{node['rstudio']['server']['base_download_url']}/rstudio-server-rhel-#{node['rstudio']['server']['version']}-#{arch}.rpm"
+    local_rstudio_server_file = "#{Chef::Config[:file_cache_path]}/rstudio-server-rhel-#{node['rstudio']['server']['version']}-#{arch}.rpm"
 end
 
+Chef::Log.info('Retrieving RStudio Server file.')
+remote_file local_rstudio_server_file do
+    source remote_rstudio_server_file 
+    action :create_if_missing
+    not_if { ::File.exists?('/etc/init/shiny-server.conf') }
+end
+
+Chef::Log.info('Installing RStudio Server via dpkg resource.')
+dpkg_package "rstudio-server" do
+    source local_rstudio_server_file
+    action :upgrade
+end if platform_family?('debian')
+
+Chef::Log.info('Installing RStudio Server via standard package resource.')
+package "rstudio-server" do
+    source local_rstudio_server_file
+    action :upgrade
+end unless platform_family?('debian')
+
 service "rstudio-server" do
-    provider Chef::Provider::Service::Upstart
+    # provider Chef::Provider::Service::Upstart
     supports :start => true, :stop => true, :restart => true
     action :start
 end
 
+
+# create our config files
 template "/etc/rstudio/rserver.conf" do
     source "etc/rstudio/rserver.conf.erb"
     mode 0644

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -14,9 +14,27 @@ when "ubuntu", "debian"
         action :install
     end
 
-    package "rstudio-server" do
+    package "libssl0.9.8" do
         action :install
     end
+
+    Chef::Log.info('Retrieving RStudio Server file.')
+    remote_rstudio_server_file = "#{node['rstudio']['server']['base_download_url']}/rstudio-server-#{node['rstudio']['server']['version']}-#{node['rstudio']['server']['arch']}.deb"
+    local_rstudio_server_file = "#{Chef::Config[:file_cache_path]}/rstudio-server-#{node['rstudio']['server']['version']}-#{node['rstudio']['server']['arch']}.deb"
+    remote_file local_rstudio_server_file do
+        source remote_rstudio_server_file 
+        action :create_if_missing
+        not_if { ::File.exists?('/etc/init/shiny-server.conf') }
+    end
+
+    Chef::Log.info('Installing RStudio Server via dpkg.')
+    dpkg_package "rstudio-server" do
+      source local_rstudio_server_file
+      action :upgrade
+    end
+
+when "redhat", "centos", "fedora"
+    Chef::Application.fatal!("Redhat based platforms are not yet supported")
 end
 
 service "rstudio-server" do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,6 +1,7 @@
 # Set up the package repository.
-case platform_family
-when "debian"
+include_recipe 'chef-sugar::default'
+
+if debian?
     include_recipe "apt"
 
     apt_repository "rstudio-cran" do
@@ -32,9 +33,23 @@ when "debian"
       source local_rstudio_server_file
       action :upgrade
     end
+end
 
-when "rhel"
-    Chef::Application.fatal!("Redhat based platforms are not yet supported")
+if rhel?
+    # Chef::Application.fatal!("Redhat based platforms are not yet supported")
+    package "R" do
+        action :install
+    end
+    
+    remote_file 'rstudio' do
+        source 'https://download2.rstudio.org/rstudio-server-rhel-0.99.483-x86_64.rpm'
+        action :create_if_missing
+    end
+    
+    package 'rstudio' do
+        source 'rstudio'
+        action :install
+    end
 end
 
 service "rstudio-server" do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,6 +1,3 @@
-# Set up the package repository.
-include_recipe 'chef-sugar::default'
-
 if debian?
     include_recipe "apt"
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,6 +1,6 @@
 # Set up the package repository.
-case node["platform"].downcase
-when "ubuntu", "debian"
+case platform_family
+when "debian"
     include_recipe "apt"
 
     apt_repository "rstudio-cran" do
@@ -33,7 +33,7 @@ when "ubuntu", "debian"
       action :upgrade
     end
 
-when "redhat", "centos", "fedora"
+when "rhel"
     Chef::Application.fatal!("Redhat based platforms are not yet supported")
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -29,16 +29,16 @@ if rhel?
     
     include_recipe 'yum-epel'
     
-    package "R" do
-        action :install
-    end
+    #package "R" do
+    #    action :install
+    #end
 
     if _64_bit?
         arch = "x86_64"
     else
         arch = "i686"
     end
-		
+
     remote_rstudio_server_file = "#{node['rstudio']['server']['base_download_url']}/rstudio-server-rhel-#{node['rstudio']['server']['version']}-#{arch}.rpm"
     local_rstudio_server_file = "#{Chef::Config[:file_cache_path]}/rstudio-server-rhel-#{node['rstudio']['server']['version']}-#{arch}.rpm"
 end
@@ -67,7 +67,6 @@ service "rstudio-server" do
     supports :start => true, :stop => true, :restart => true
     action :start
 end
-
 
 # create our config files
 template "/etc/rstudio/rserver.conf" do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -1,34 +1,19 @@
 if debian?
-    include_recipe "apt"
 
-    apt_repository "rstudio-cran" do
-        uri node['rstudio']['apt']['uri']
-        keyserver node['rstudio']['apt']['keyserver']
-        key node['rstudio']['apt']['key']
-        distribution "#{node['lsb']['codename']}/"
+    package "libssl1.0.0" do
+      action :install
+    end if ubuntu?
+
+    package "psmisc" do
+      action :install
     end
-
-    package "r-base" do
-        action :install
-    end
-
-    #package "libssl0.9.8" do
-    #    action :install
-    #end
 
     remote_rstudio_server_file = "#{node['rstudio']['server']['base_download_url']}/rstudio-server-#{node['rstudio']['server']['version']}-#{node['rstudio']['server']['arch']}.deb"
     local_rstudio_server_file = "#{Chef::Config[:file_cache_path]}/rstudio-server-#{node['rstudio']['server']['version']}-#{node['rstudio']['server']['arch']}.deb"
 
 end
 
-if rhel?
-    # Chef::Application.fatal!("Redhat based platforms are not yet supported")
-    
-    include_recipe 'yum-epel'
-    
-    #package "R" do
-    #    action :install
-    #end
+if rhel? or amazon_linux?
 
     if _64_bit?
         arch = "x86_64"

--- a/spec/cran_spec.rb
+++ b/spec/cran_spec.rb
@@ -1,8 +1,9 @@
-require 'spec_helper'
+require 'chefspec'
+require 'chefspec/berkshelf'
 
 describe 'rstudio::cran' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04')
+    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
     runner.converge(described_recipe)
   end
 end

--- a/spec/nginx_spec.rb
+++ b/spec/nginx_spec.rb
@@ -1,9 +1,10 @@
-require 'spec_helper'
+require 'chefspec'
+require 'chefspec/berkshelf'
 
 describe 'rstudio::nginx' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04')
-    runner.node.set['rstudio']['nginx']['server_name'] = 'test.example.com'
+    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
+    runner.node.normal['rstudio']['nginx']['server_name'] = 'test.example.com'
     runner.converge(described_recipe)
   end
 
@@ -11,7 +12,7 @@ describe 'rstudio::nginx' do
     stub_command('which nginx').and_return(true)
   end
 
-  it 'should create a knife.rb' do
+  it 'should create a template file' do
     template_file = '/etc/nginx/sites-available/test.example.com'
     expect(chef_run).to render_file(template_file)
   end

--- a/spec/pam_spec.rb
+++ b/spec/pam_spec.rb
@@ -1,9 +1,10 @@
-require 'spec_helper'
+require 'chefspec'
+require 'chefspec/berkshelf'
 
 describe 'rstudio::pam' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new platform: 'ubuntu', version: '12.04' do |node|
-      node.set['rstudio']['nginx']['server_name'] = 'test.example.com'
+    runner = ChefSpec::SoloRunner.new platform: 'ubuntu', version: '16.04' do |node|
+      node.normal['rstudio']['nginx']['server_name'] = 'test.example.com'
     end.converge(described_recipe)
   end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,16 +1,10 @@
-require 'spec_helper'
+require 'chefspec'
+require 'chefspec/berkshelf'
 
 describe 'rstudio::server' do
-  let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '12.04')
-    runner.converge(described_recipe)
-  end
+  platform 'ubuntu', '16.04'
 
-  it('should install r-base') do
-    expect(chef_run).to install_package('r-base')
-  end
-
-  it('should install rstudio-server') do
-    expect(chef_run).to install_package('rstudio-server')
+  context 'basic package install' do
+    it {is_expected.to install_package(['rstudio-server', 'libssl1.0.0', 'psmisc'])}
   end
 end

--- a/templates/default/etc/nginx/rstudio.conf.erb
+++ b/templates/default/etc/nginx/rstudio.conf.erb
@@ -1,7 +1,7 @@
 <% if @use_ssl %>
 server {
     listen      80;
-    server_name <%= node[:rstudio][:nginx][:server_name] %>;
+    server_name <%= node['rstudio']['nginx']['server_name'] %>;
     rewrite     ^   https://$server_name$request_uri? permanent;
 }
 
@@ -10,41 +10,41 @@ server {
   <% if @use_ssl %>
   listen                    443 ssl;
   ssl                       on;
-  ssl_certificate           <%= node[:rstudio][:ssl][:crt_file] %>;
-  ssl_certificate_key       <%= node[:rstudio][:ssl][:key_file] %>;
-  ssl_protocols             SSLv3 TLSv1;
+  ssl_certificate           <%= node['rstudio']['ssl']['crt_file'] %>;
+  ssl_certificate_key       <%= node['rstudio']['ssl']['key_file'] %>;
+  ssl_protocols             TLSv1.2;
   ssl_ciphers               ALL:!aNULL:!ADH:!eNULL:!LOW:!EXP:RC4+RSA:+HIGH:+MEDIUM;
   <% else %>
-  listen        <%= node[:rstudio][:nginx][:port] %>;
+  listen        <%= node['rstudio']['nginx']['port'] %>;
   <% end %>
-  server_name   <%= node[:rstudio][:nginx][:server_name] %>;
+  server_name   <%= node['rstudio']['nginx']['server_name'] %>;
 
-  <% if node[:rstudio][:nginx][:location] != '' %>
-  location <%= node[:rstudio][:nginx][:location] %> {
-  <% if node[:rstudio][:nginx][:location] != '/' %>
-    rewrite ^<%= node[:rstudio][:nginx][:location] %>(.*)$ /$1 break;
+  <% if node['rstudio']['nginx']['location'] != '' %>
+  location <%= node['rstudio']['nginx']['location'] %> {
+  <% if node['rstudio']['nginx']['location'] != '/' %>
+    rewrite ^<%= node['rstudio']['nginx']['location'] %>(.*)$ /$1 break;
   <% end %>
-    proxy_pass http://<%= node[:rstudio][:server][:www_address] %>:<%= node[:rstudio][:server][:www_port] %>;
-    proxy_redirect http://<%= node[:rstudio][:server][:www_address] %>:<%= node[:rstudio][:server][:www_port] %>/ $scheme://$host<%= node[:rstudio][:nginx][:location] %>;
+    proxy_pass http://<%= node['rstudio']['server']['www_address'] %>:<%= node['rstudio']['server']['www_port'] %>;
+    proxy_redirect http://<%= node['rstudio']['server']['www_address'] %>:<%= node['rstudio']['server']['www_port'] %>/ $scheme://$host<%= node['rstudio']['nginx']['location'] %>;
   }
   <% end %>
 
-  <% if node[:rstudio][:nginx][:shiny_location] != '' %>
+  <% if node['rstudio']['nginx']['shiny_location'] != '' %>
   # Looks like we've configured and are using the Shiny server as well. This will proxy that
   # to the Shiny server. 
-  <% if node[:rstudio][:nginx][:shiny_location] == node[:rstudio][:nginx][:location] %>
+  <% if node['rstudio']['nginx']['shiny_location'] == node['rstudio']['nginx']['location'] %>
   # RStudio and Shiny can't live at the same HTTP location!
   <% else %>
-  location <%= node[:rstudio][:nginx][:shiny_location] %> {
+  location <%= node['rstudio']['nginx']['shiny_location'] %> {
   <% if node['rstudio']['shiny']['htpasswd_file'] != '' %>
     auth_basic "Shiny";
     auth_basic_user_file <%= node['rstudio']['shiny']['htpasswd_file'] %>;
   <% end %>
-  <% if node[:rstudio][:nginx][:shiny_location] != '/' %>
-    rewrite ^<%= node[:rstudio][:nginx][:shiny_location] %>(.*)$ /$1 break;
+  <% if node['rstudio']['nginx']['shiny_location'] != '/' %>
+    rewrite ^<%= node['rstudio']['nginx']['shiny_location'] %>(.*)$ /$1 break;
   <% end %>
-    proxy_pass http://<%= node[:rstudio][:shiny][:www_address] %>:<%= node[:rstudio][:shiny][:www_port] %>;
-    proxy_redirect http://<%= node[:rstudio][:shiny][:www_address] %>:<%= node[:rstudio][:shiny][:www_port] %>/ $scheme://$host<%= node[:rstudio][:nginx][:location] %>;
+    proxy_pass http://<%= node['rstudio']['shiny']['www_address'] %>:<%= node['rstudio']['shiny']['www_port'] %>;
+    proxy_redirect http://<%= node['rstudio']['shiny']['www_address'] %>:<%= node['rstudio']['shiny']['www_port'] %>/ $scheme://$host<%= node['rstudio']['nginx']['location'] %>;
   }
   <% end %>
   <% end %>

--- a/templates/default/etc/rstudio/rserver.conf.erb
+++ b/templates/default/etc/rstudio/rserver.conf.erb
@@ -1,16 +1,16 @@
 # network configuration
-www-port=<%= node[:rstudio][:server][:www_port] %>
-www-address=<%= node[:rstudio][:server][:www_address] %>
+www-port=<%= node['rstudio']['server']['www_port'] %>
+www-address=<%= node['rstudio']['server']['www_address'] %>
 
-<% if node[:rstudio][:server][:ld_library_path] != '' %>
+<% if node['rstudio']['server']['ld_library_path'] != '' %>
 # Library paths
-rsession-ld-library-path=<%= node[:rstudio][:server][:ld_library_path] %>
+rsession-ld-library-path=<%= node['rstudio']['server']['ld_library_path'] %>
 <% end %>
 
-<% if node[:rstudio][:server][:r_binary_path] != '' %>
-rsession-which-r=<%= node[:rstudio][:server][:r_binary_path] %>
+<% if node['rstudio']['server']['r_binary_path'] != '' %>
+rsession-which-r=<%= node['rstudio']['server']['r_binary_path'] %>
 <% end %>
 
-<% if node[:rstudio][:server][:user_group] != '' %>
-auth-required-user-group=<%= node[:rstudio][:server][:user_group] %>
+<% if node['rstudio']['server']['user_group'] != '' %>
+auth-required-user-group=<%= node['rstudio']['server']['user_group'] %>
 <% end %>

--- a/templates/default/etc/rstudio/rserver.conf.erb
+++ b/templates/default/etc/rstudio/rserver.conf.erb
@@ -1,11 +1,16 @@
+# network configuration
 www-port=<%= node[:rstudio][:server][:www_port] %>
 www-address=<%= node[:rstudio][:server][:www_address] %>
+
 <% if node[:rstudio][:server][:ld_library_path] != '' %>
+# Library paths
 rsession-ld-library-path=<%= node[:rstudio][:server][:ld_library_path] %>
 <% end %>
+
 <% if node[:rstudio][:server][:r_binary_path] != '' %>
 rsession-which-r=<%= node[:rstudio][:server][:r_binary_path] %>
 <% end %>
+
 <% if node[:rstudio][:server][:user_group] != '' %>
 auth-required-user-group=<%= node[:rstudio][:server][:user_group] %>
 <% end %>

--- a/templates/default/etc/rstudio/rsession.conf.erb
+++ b/templates/default/etc/rstudio/rsession.conf.erb
@@ -1,7 +1,7 @@
-session-timeout-minutes=<%= node[:rstudio][:session][:timeout] %>
+session-timeout-minutes=<%= node['rstudio']['session']['timeout'] %>
 
-<% if node[:rstudio][:session][:package_path] != '' %>
-r-libs-user=<%= node[:rstudio][:session][:package_path] %>
+<% if node['rstudio']['session']['package_path'] != '' %>
+r-libs-user=<%= node['rstudio']['session']['package_path'] %>
 <% end %>
 
-r-cran-repos=<%= node[:rstudio][:session][:cran_repo] %>
+r-cran-repos=<%= node['rstudio']['session']['cran_repo'] %>

--- a/templates/default/etc/rstudio/rsession.conf.erb
+++ b/templates/default/etc/rstudio/rsession.conf.erb
@@ -1,5 +1,7 @@
 session-timeout-minutes=<%= node[:rstudio][:session][:timeout] %>
+
 <% if node[:rstudio][:session][:package_path] != '' %>
 r-libs-user=<%= node[:rstudio][:session][:package_path] %>
 <% end %>
+
 r-cran-repos=<%= node[:rstudio][:session][:cran_repo] %>

--- a/test/integration/default/data_bags/users.json
+++ b/test/integration/default/data_bags/users.json
@@ -1,0 +1,17 @@
+{
+  "id": "bofh",
+  "password": "$1$d...HgH0",
+  "ssh_keys": [
+    "ssh-rsa AAA123...xyz== foo",
+    "ssh-rsa AAA456...uvw== bar"
+  ],
+  "groups": [ "sysadmin", "dba", "devops" ],
+  "uid": 2001,
+  "shell": "\/bin\/bash",
+  "comment": "BOFH",
+  "nagios": {
+    "pager": "8005551212@txt.att.net",
+    "email": "bofh@example.com"
+  },
+  "openid": "bofh.myopenid.com"
+}

--- a/test/integration/default/test-rstudio.rb
+++ b/test/integration/default/test-rstudio.rb
@@ -1,0 +1,9 @@
+describe port(8787) do
+  it { should be_listening }
+  its('addresses') { should include '127.0.0.1' }
+end
+
+# http://inspec.io/docs/reference/resources/service/
+describe service('rstudio-server') do
+  it { should be_running }
+end

--- a/test/integration/shiny/test-shiny.rb
+++ b/test/integration/shiny/test-shiny.rb
@@ -1,0 +1,3 @@
+describe service('shiny-server') do
+  it { should be_running }
+end


### PR DESCRIPTION
A larger PR than I intended, this is primarily for AWS Linux support:
+ Support for Amazon Linux and Centos platforms
+ Kitchen coverage is expanded to the new platforms
+ Default version of R Studio is bumped a couple revs
+ cran_repo is moved to a HTTPS version by default
+ Update for some foodcritic cops

Sorry for the scope on this change. I'm trying to close out my own forks. If accepted, I'll 
do another pass to bring the R Studio version more current and update for the recent shift 
to cookstyle away from rubocop.